### PR TITLE
Add login functionality to BC01 Simulator

### DIFF
--- a/Proj_BC01_Simulator/mainwindow.cpp
+++ b/Proj_BC01_Simulator/mainwindow.cpp
@@ -1,18 +1,23 @@
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 
-#include "../BC01_GENERIC_POINT/BC01_GENERIC_POINT.h"
-#include "../BC02_POINT_TYPA/BC02_POINT_TYPA.h"
-
-
-MainWindow::MainWindow(QWidget *parent)
-    : QMainWindow(parent)
-    , ui(new Ui::MainWindow)
+MainWindow::MainWindow(QWidget *parent) :
+    QMainWindow(parent),
+    ui(new Ui::MainWindow)
 {
     ui->setupUi(this);
-    /*
+    connect(ui->loginButton, &QPushButton::clicked, this, &MainWindow::checkLogin);
+}
 
-    */
+void MainWindow::checkLogin() {
+    QString username = ui->usernameLineEdit->text();
+    QString password = ui->passwordLineEdit->text();
+
+    if (username == "admin" && password == "secret") {
+        QMessageBox::information(this, "Success", "Login successful!");
+    } else {
+        QMessageBox::warning(this, "Error", "Invalid username or password");
+    }
 }
 
 MainWindow::~MainWindow()

--- a/Proj_BC01_Simulator/mainwindow.h
+++ b/Proj_BC01_Simulator/mainwindow.h
@@ -2,20 +2,22 @@
 #define MAINWINDOW_H
 
 #include <QMainWindow>
+#include <QMessageBox>
 
-QT_BEGIN_NAMESPACE
 namespace Ui {
 class MainWindow;
 }
-QT_END_NAMESPACE
 
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
 
 public:
-    MainWindow(QWidget *parent = nullptr);
+    explicit MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
+
+private slots:
+    void checkLogin();
 
 private:
     Ui::MainWindow *ui;

--- a/Proj_BC01_Simulator/mainwindow.ui
+++ b/Proj_BC01_Simulator/mainwindow.ui
@@ -13,7 +13,50 @@
   <property name="windowTitle">
    <string>MainWindow</string>
   </property>
-  <widget class="QWidget" name="centralwidget"/>
+  <widget class="QWidget" name="centralwidget">
+   <widget class="QLineEdit" name="usernameLineEdit">
+    <property name="geometry">
+     <rect>
+      <x>300</x>
+      <y>200</y>
+      <width>200</width>
+      <height>24</height>
+     </rect>
+    </property>
+    <property name="placeholderText">
+     <string>Username</string>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="passwordLineEdit">
+    <property name="geometry">
+     <rect>
+      <x>300</x>
+      <y>240</y>
+      <width>200</width>
+      <height>24</height>
+     </rect>
+    </property>
+    <property name="echoMode">
+     <enum>QLineEdit::Password</enum>
+    </property>
+    <property name="placeholderText">
+     <string>Password</string>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="loginButton">
+    <property name="geometry">
+     <rect>
+      <x>350</x>
+      <y>280</y>
+      <width>100</width>
+      <height>24</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Login</string>
+    </property>
+   </widget>
+  </widget>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">
     <rect>


### PR DESCRIPTION
This PR adds a basic login system to the BC01 Simulator. Changes include:

- Added login UI elements (username field, password field, login button)
- Implemented login authentication logic
- Added `checkLogin()` slot to handle login attempts
- Set up password field with secure echo mode
- Added basic validation (admin/secret credentials)

The login form includes proper placeholder text and password masking for security. Currently uses hardcoded credentials for testing purposes.